### PR TITLE
adding better functionalities for data loader

### DIFF
--- a/examples/linkproppred/tkgl-polecat/polecat_example.py
+++ b/examples/linkproppred/tkgl-polecat/polecat_example.py
@@ -11,14 +11,26 @@ test_mask = dataset.test_mask
 data = dataset.get_TemporalData()
 metric = dataset.eval_metric
 
+print ("there are {} nodes and {} edges".format(dataset.num_nodes, dataset.num_edges))
+print ("there are {} relation types".format(dataset.num_rels))
+
 
 timestamp = data.t
 head = data.src
 tail = data.dst
 edge_type = data.edge_type #relation
 
-print (edge_type)
-
 train_data = data[train_mask]
 val_data = data[val_mask]
 test_data = data[test_mask]
+
+
+from tgb.linkproppred.dataset import LinkPropPredDataset
+
+# data loading
+dataset = LinkPropPredDataset(name=DATA, root="datasets", preprocess=True)
+data = dataset.full_data  
+metric = dataset.eval_metric
+sources = dataset.full_data['sources']
+print (sources.dtype)
+

--- a/tgb/linkproppred/dataset.py
+++ b/tgb/linkproppred/dataset.py
@@ -257,9 +257,9 @@ class LinkPropPredDataset(object):
         self._node_feat = node_feat
 
         full_data = {
-            "sources": sources,
-            "destinations": destinations,
-            "timestamps": timestamps,
+            "sources": sources.astype(int),
+            "destinations": destinations.astype(int),
+            "timestamps": timestamps.astype(int),
             "edge_idxs": edge_idxs,
             "edge_feat": edge_feat,
             "w": weights,
@@ -268,7 +268,7 @@ class LinkPropPredDataset(object):
 
         #* for tkg
         if ("edge_type" in df):
-            edge_type = np.array(df["edge_type"])
+            edge_type = np.array(df["edge_type"]).astype(int)
             self._edge_type = edge_type
         full_data["edge_type"] = edge_type
 
@@ -341,6 +341,46 @@ class LinkPropPredDataset(object):
         self.ns_sampler.load_eval_set(
             fname=self.meta_dict["test_ns"], split_mode="test"
         )
+
+    @property
+    def num_nodes(self) -> int:
+        r"""
+        Returns the total number of unique nodes in the dataset 
+        Returns:
+            num_nodes: int, the number of unique nodes
+        """
+        src = self._full_data["sources"]
+        dst = self._full_data["destinations"]
+        all_nodes = np.concatenate((src, dst), axis=0)
+        print (all_nodes.shape)
+        uniq_nodes = np.unique(all_nodes, axis=0)
+        print (uniq_nodes.shape)
+        return uniq_nodes.shape[0]
+    
+
+    @property
+    def num_edges(self) -> int:
+        r"""
+        Returns the total number of edges in the dataset
+        Returns:
+            num_edges: int, the number of edges
+        """
+        src = self._full_data["sources"]
+        return src.shape[0]
+    
+
+    @property
+    def num_rels(self) -> int:
+        r"""
+        Returns the number of relation types in the dataset
+        Returns:
+            num_rels: int, the number of relation types
+        """
+        #* if it is a homogenous graph
+        if ("edge_type" not in self._full_data):
+            return 1
+        else:
+            return np.unique(self._full_data["edge_type"]).shape[0]
 
     @property
     def node_feat(self) -> Optional[np.ndarray]:

--- a/tgb/linkproppred/dataset.py
+++ b/tgb/linkproppred/dataset.py
@@ -270,7 +270,7 @@ class LinkPropPredDataset(object):
         if ("edge_type" in df):
             edge_type = np.array(df["edge_type"]).astype(int)
             self._edge_type = edge_type
-        full_data["edge_type"] = edge_type
+            full_data["edge_type"] = edge_type
 
         self._full_data = full_data
         _train_mask, _val_mask, _test_mask = self.generate_splits(full_data)

--- a/tgb/linkproppred/dataset_pyg.py
+++ b/tgb/linkproppred/dataset_pyg.py
@@ -59,6 +59,33 @@ class PyGLinkPropPredDataset(Dataset):
             negative_sampler: NegativeEdgeSampler
         """
         return self._ns_sampler
+    
+    @property
+    def num_nodes(self) -> int:
+        r"""
+        Returns the total number of unique nodes in the dataset 
+        Returns:
+            num_nodes: int, the number of unique nodes
+        """
+        return self.dataset.num_nodes
+    
+    @property
+    def num_rels(self) -> int:
+        r"""
+        Returns the total number of unique relations in the dataset 
+        Returns:
+            num_rels: int, the number of unique relations
+        """
+        return self.dataset.num_rels
+    
+    @property
+    def num_edges(self) -> int:
+        r"""
+        Returns the total number of edges in the dataset 
+        Returns:
+            num_edges: int, the number of edges
+        """
+        return self.dataset.num_edges
 
     def load_val_ns(self) -> None:
         r"""


### PR DESCRIPTION
- enforced source, destination, edge_type and timestamp to be `int`
- added `num_nodes`, `num_edges`, `num_rels` for ease of use

see [`polecat_example.py`](https://github.com/JuliaGast/TGB2/blob/andy_new/examples/linkproppred/tkgl-polecat/polecat_example.py) for usage example